### PR TITLE
Ensure that test output doesn't end up in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,6 @@
 .vscode
 .npmignore
 webpack.config.js
+log.log
 test/
 dist/


### PR DESCRIPTION
I noticed that the npm package contains a 4.6MB file called "log.log" that appears to be Jasmine test output or something. Assuming that it's just a minor oversight, I figured I'd add a line to the .npmignore file to prevent it from ending up in the package.