### PR TITLE
#16, #23 Customize error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,33 @@ env.addFormat('isOk', function(schema, tpl){
 env.validate('ok', 'valid') // => undefined if schema contains isOk property
 ```
 
+### setErrorHandler(errorHandler: Function)
+
+Specify custom error handler which will be used in generated functions when problem found.
+The function should return a string expression, which will be executed when generated validator function is executed. The simpliest use case is the default one @see `template/defaultErrorHandler`
+```javascript
+ function defaultErrorHandler(errorType) {
+   return `return "${errorType}: ${tpl.data}";`;
+ }
+```
+It returns an expression 'return ...', so the output is an error string.
+
+```javascript
+djv({ errorHandler: () => 'return { error: true };' }) // => returns an object
+djv({
+ errorHandler: function customErrorHandler(errorType, property) {
+   return `errors.push({
+     type: '${type}',
+     schema: '${this.schema[this.schema.length - 1]}',
+     data: '${this.data[this.data.length - 1]}'
+   });
+ }
+})`;
+```
+When a custom error handler is used, the template body function adds a `error` variable inside a generated validator, which can be used to put error information. `errorType` is always passed to error handler function. Some validate utilities put extra argument, like f.e. currently processed property value. Inside the handler context is a templater instance, which contains `this.schema`, `this.data` paths arrays to identify validator position.
+@see test/index/setErrorHandler for more examples
+
+
 ## Tests
 
 ```

--- a/lib/djv.js
+++ b/lib/djv.js
@@ -3,24 +3,55 @@ const { restore } = require('./utils/template');
 const formats = require('./utils/formats');
 const { generate, State } = require('./utils/state');
 
-function Environment() {
-  if (!(this instanceof Environment)) { return new Environment(); }
+/**
+ * Configuration for template
+ * @typedef {object} DjvConfig
+ * @property {boolean?} inner - a generating object should be considered as inner
+ * Default value is false/undefined.
+ * If true, then it avoid creating variables in a generated function body,
+ * however without proper wrapper function approach will not work.
+ * @see template/body, template/body
+ * @property {object?} formats - an object containing list of formatters to add for environment
+ * @property {function?} errorHandler - a handler to use for generating custom error messages
+ */
 
+/**
+ * @name Environment
+ * @description
+ * Key constructor used for creating enivornment instance
+ * @type {function} constructor
+ * @param {DjvConfig} options passed to templater and utilities
+ *
+ * Usage
+ *
+ * ```javascript
+ * const env = djv();
+ * const env = new djv();
+ * const env = new djv({ errorHandler: () => ';' });
+ * ```
+ */
+function Environment(options = {}) {
+  if (!(this instanceof Environment)) { return new Environment(options); }
+
+  this.options = options;
   this.resolved = {};
   this.state = new State(null, this);
+
+  this.addFormat(options.formats);
 }
 
 Environment.prototype = {
   /**
    * check if object correspond to schema
    *
-   * ### Examples:
+   * Usage
    *
-   *    env.validate('test#/common', { type: 'common' });
-   *    // => undefined
+   * ```javascript
+   * env.validate('test#/common', { type: 'common' });
+   * // => undefined
    *
-   *    env.validate('test#/common', { type: 'custom' });
-   *    // => 'required: data'
+   * env.validate('test#/common', { type: 'custom' });
+   * // => 'required: data'
    *
    * @param {string} name
    * @param {object} object
@@ -33,9 +64,11 @@ Environment.prototype = {
   /**
    * add schema to djv environment
    *
-   * ### Examples:
+   * Usage
    *
-   *    env.addSchema('test', jsonSchema);
+   * ```javascript
+   * env.addSchema('test', jsonSchema);
+   * ```
    *
    * @param {string?} name
    * @param {object} schema
@@ -46,7 +79,7 @@ Environment.prototype = {
     const realSchema = typeof name === 'object' ? name : schema;
     const resolved = {
       schema: realSchema,
-      fn: generate(this, realSchema),
+      fn: generate(this, realSchema, undefined, this.options),
     };
 
     [name, schema.id]
@@ -60,39 +93,13 @@ Environment.prototype = {
   },
 
   /**
-   * @name addFormat
-   * @type function
-   * @description
-   * Add formatter to djv environment.
-   * When a string is passed it is interpreted as an expression which
-   * when returns `true` goes with an error, when returns `false` then a property is valid.
-   * When a function is passed it will be executed during schema compilation
-   * with a current schema and template helper arguments.
-   * @see utils/formats
-   *
-   * ### Examples:
-   *
-   *    env.addFormat('UpperCase', '%s !== %s.toUpperCase()');
-   *    // or
-   *    env.addFormat('isOk', function(schema, tpl){
-   *      return `!${schema.isOk} || %s !== %s.toUpperCase()`;
-   *    });
-   *
-   * @param {string?} name
-   * @param {string/function} formatter
-   * @returns {formatter}
-   */
-  addFormat(name, formatter) {
-    formats[name] = formatter;
-    return formatter;
-  },
-
-  /**
    * removes a schema or the whole structure from djv environment
    *
-   * ### Examples:
+   * Usage
    *
-   *    env.removeSchema('test');
+   * ```javascript
+   * env.removeSchema('test');
+   * ```
    *
    * @param {string} name
    */
@@ -107,10 +114,12 @@ Environment.prototype = {
   /**
    * resolves name by existing environment
    *
-   * ### Examples:
+   * Usage
    *
-   *    env.resolve('test');
-   *    // => { name: 'test', schema: {} }, fn: ... }
+   * ```javascript
+   * env.resolve('test');
+   * // => { name: 'test', schema: {} }, fn: ... }
+   * ```
    *
    * @param {string} name
    * @returns {resolved}
@@ -129,10 +138,12 @@ Environment.prototype = {
   /**
    * exports the whole structure object from environment or by resolved name
    *
-   * ### Examples:
+   * Usage
    *
-   *    env.export();
-   *    // => { test: { name: 'test', schema: {}, ... } }
+   * ```javascript
+   * env.export();
+   * // => { test: { name: 'test', schema: {}, ... } }
+   * ```
    *
    * @param {string} name
    * @returns {serializedInternalState}
@@ -162,9 +173,11 @@ Environment.prototype = {
 
   /**
    * imports all found structure objects to internal environment structure
-   * ### Examples:
+   * Usage
    *
-   *    env.import(config);
+   * ```javascript
+   * env.import(config);
+   * ```
    *
    * @param {object} config - internal structure or only resolved schema object
    */
@@ -177,9 +190,84 @@ Environment.prototype = {
 
     Object.keys(restoreData).forEach((key) => {
       const { name, schema, fn: source } = restoreData[key];
-      const fn = restore(source, schema);
+      const fn = restore(source, schema, this.options);
       this.resolved[name] = { name, schema, fn };
     });
+  },
+
+  /**
+   * @name addFormat
+   * @type function
+   * @description
+   * Add formatter to djv environment.
+   * When a string is passed it is interpreted as an expression which
+   * when returns `true` goes with an error, when returns `false` then a property is valid.
+   * When a function is passed it will be executed during schema compilation
+   * with a current schema and template helper arguments.
+   * @see utils/formats
+   *
+   * Usage
+   *
+   * ```javascript
+   * env.addFormat('UpperCase', '%s !== %s.toUpperCase()');
+   * // or
+   * env.addFormat('isOk', function(schema, tpl){
+   *   return `!${schema.isOk} || %s !== %s.toUpperCase()`;
+   * });
+   * ```
+   *
+   * @param {string/object?} name
+   * @param {string/function} formatter
+   */
+  addFormat(name, formatter) {
+    if (typeof name === 'string') {
+      formats[name] = formatter;
+      return;
+    }
+
+    if (typeof name === 'object') {
+      Object.assign(formats, name);
+    }
+  },
+
+  /**
+   * @name setErrorHandler
+   * @type function
+   * @description
+   * Specify custom error handler which will be used in generated functions when problem found.
+   * The function should return a string expression, which will be executed when generated
+   * validator function is executed. The simpliest use case is the default one
+   * @see template/defaultErrorHandler
+   * ```javascript
+   *  function defaultErrorHandler(errorType) {
+   *    return `return "${errorType}: ${tpl.data}";`;
+   *  }
+   * ```
+   * It returns an expression 'return ...', so the output is an error string.
+   * ```
+   * Usage
+   * ```javascript
+   * djv({ errorHandler: () => 'return { error: true };' }) // => returns an object
+   * djv({
+   *  errorHandler: function customErrorHandler(errorType, property) {
+   *    return `errors.push({
+   *      type: '${type}',
+   *      schema: '${this.schema[this.schema.length - 1]}',
+   *      data: '${this.data[this.data.length - 1]}'
+   *    });
+   *  }
+   * })`;
+   * ```
+   * When a custom error handler is used, the template body function adds a `error` variable inside
+   * a generated validator, which can be used to put error information. `errorType` is always
+   * passed to error handler function. Some validate utilities put extra argument, like f.e.
+   * currently processed property value. Inside the handler context is a templater instance,
+   * which contains `this.schema`, `this.data` paths arrays to identify validator position.
+   * @see test/index/setErrorHandler for more examples
+   * @param {function} errorHandler - a function called each time compiler creates an error branch
+   */
+  setErrorHandler(errorHandler) {
+    Object.assign(this.options, { errorHandler });
   }
 };
 

--- a/lib/djv.js
+++ b/lib/djv.js
@@ -244,7 +244,6 @@ Environment.prototype = {
    *  }
    * ```
    * It returns an expression 'return ...', so the output is an error string.
-   * ```
    * Usage
    * ```javascript
    * djv({ errorHandler: () => 'return { error: true };' }) // => returns an object

--- a/lib/utils/state.js
+++ b/lib/utils/state.js
@@ -1,11 +1,6 @@
 const { list: validators } = require('../validators');
 const { body, restore, template } = require('./template');
 
-/**
- * Configuration for template
- * @typedef {object} TemplateConfig
- * @property {boolean} inner - a generating object should be considered as inner
- */
 function State(schema = {}, env) {
   this.push(schema);
 
@@ -18,7 +13,7 @@ function State(schema = {}, env) {
 }
 
 function generate(env, schema, state = new State(schema, env), options) {
-  const tpl = template(state);
+  const tpl = template(state, options);
   tpl.visit(schema);
 
   const source = body(tpl, state, options);

--- a/lib/utils/template.js
+++ b/lib/utils/template.js
@@ -11,9 +11,10 @@
  * Provides a templater function, which adds a line of code into generated function body.
  *
  * @param {object} state - used in visit and reference method to iterate and find schemas.
+ * @param {DjvConfig} options
  * @return {function} tpl
  */
-function template(state) {
+function template(state, options) {
   function tpl(expression, ...args) {
     let last;
 
@@ -33,6 +34,12 @@ function template(state) {
     return tpl;
   }
 
+  const error = typeof options.errorHandler === 'function' ?
+    options.errorHandler :
+    function defaultErrorHandler(errorType) {
+      return `return "${errorType}: ${tpl.data}";`;
+    };
+
   Object.assign(tpl, {
     cachedIndex: 0,
     cached: [],
@@ -47,9 +54,7 @@ function template(state) {
       return `(i${layer[expression]} = ${expression})`;
     },
     data: ['data'],
-    error(errorType) {
-      return `return "${errorType}: ${tpl.data}";`;
-    },
+    error,
     lines: [],
     push: tpl,
     resolve(url) {
@@ -81,7 +86,7 @@ function template(state) {
  *
  * @param {string} source - function inner & outer body
  * @param {object} schema - passed as argument to meta function
- * @param {TemplateConfig} config
+ * @param {DjvConfig} config
  * @return {function} tpl
  */
 function restore(source, schema, { inner } = {}) {
@@ -104,20 +109,33 @@ function restore(source, schema, { inner } = {}) {
  * @description
  * Generate a function body, containing internal variables and helpers
  *
- * @param {object} context - template instance, containing all analyzed schema related data
+ * @param {object} tpl - template instance, containing all analyzed schema related data
  * @param {object} state - state of schema generation
- * @param {TemplateConfig} config
+ * @param {DjvConfig} config
  * @return {string} body
  */
-function body(context, state, { inner } = {}) {
-  // @see map array with holes trick
-  // http://2ality.com/2013/11/initializing-arrays.html
-  const dynamicVariables = !context.cachedIndex ? '' :
-    `var i${Array(...Array(context.cachedIndex))
+function body(tpl, state, { inner, errorHandler } = {}) {
+  let dynamicVariables = '';
+  let errors = '';
+  let dynamicFunctions = '';
+
+  if (tpl.cachedIndex) {
+    // @see map array with holes trick
+    // http://2ality.com/2013/11/initializing-arrays.html
+    // TODO change var to const
+    dynamicVariables = `var i${Array(...Array(tpl.cachedIndex))
       .map((value, i) => i + 1)
       .join(',i')};`;
+  }
+  if (errorHandler) {
+    /**
+     * @var {array} errors - empty array for pushing errors ability
+     * @see errorHandler
+     */
+    dynamicVariables += 'var errors = [];';
+    errors = 'if(errors.length) return errors;';
+  }
 
-  let dynamicFunctions = '';
   if (!inner && state.context.length) {
     const functions = [];
     const references = [];
@@ -132,8 +150,14 @@ function body(context, state, { inner } = {}) {
     dynamicFunctions = `var f${functions.concat(references).join(',f')};`;
   }
 
-  const source = `${dynamicFunctions}return function f0(data){"use strict";${dynamicVariables}${context.lines.join('\n')}}`;
-  // TODO change var to const
+  const source = `${dynamicFunctions}
+    return function f0(data){
+      "use strict";
+      ${dynamicVariables}
+      ${tpl.lines.join('\n')}
+      ${errors}
+    }`;
+
   return source;
 }
 

--- a/lib/validators/$ref.js
+++ b/lib/validators/$ref.js
@@ -3,6 +3,8 @@ module.exports = function $ref(schema, tpl) {
     return;
   }
 
-  tpl(`if (${tpl.resolve(schema.$ref)}(%s))`, tpl.data)
-    .push(tpl.error('$ref'));
+  const condition = `${tpl.resolve(schema.$ref)}(%s)`;
+  const error = tpl.error('$ref');
+
+  tpl(`if (${condition}) ${error}`, tpl.data);
 };

--- a/lib/validators/allOf.js
+++ b/lib/validators/allOf.js
@@ -3,6 +3,8 @@ module.exports = function allOf(schema, tpl) {
     return;
   }
 
-  tpl('if (')(schema.allOf.map(reference => tpl.resolve(reference))
-    .join('(%s) || '), tpl.data)('(%s))', tpl.data)(tpl.error('allOf'));
+  const condition = `${schema.allOf.map(reference => `${tpl.resolve(reference)}`).join('(%s) || ')}(%s)`;
+  const error = tpl.error('allOf');
+
+  tpl(`if (${condition}) ${error}`, tpl.data);
 };

--- a/lib/validators/anyOf.js
+++ b/lib/validators/anyOf.js
@@ -3,6 +3,8 @@ module.exports = function anyOf(schema, tpl) {
     return;
   }
 
-  tpl(`if (${schema.anyOf.map(reference => `${tpl.resolve(reference)}(%s)`).join(' && ')})`, tpl.data)
-    .push(tpl.error('anyOf'));
+  const condition = schema.anyOf.map(reference => `${tpl.resolve(reference)}(%s)`).join(' && ');
+  const error = tpl.error('anyOf');
+
+  tpl(`if (${condition}) ${error}`, tpl.data);
 };

--- a/lib/validators/format.js
+++ b/lib/validators/format.js
@@ -6,10 +6,11 @@ module.exports = function property(schema, tpl) {
     return;
   }
 
-  const formatterExpression = asExpression(formats[schema.format], schema, tpl);
-  if (!formatterExpression) {
+  const condition = asExpression(formats[schema.format], schema, tpl);
+  if (!condition) {
     return;
   }
+  const error = tpl.error('format');
 
-  tpl(`if (${formatterExpression}) ${tpl.error('format')}`, tpl.data);
+  tpl(`if (${condition}) ${error}`, tpl.data);
 };

--- a/lib/validators/not.js
+++ b/lib/validators/not.js
@@ -3,6 +3,5 @@ module.exports = function not(schema, tpl) {
     return;
   }
 
-  tpl(`if (!${tpl.resolve(schema.not)}(%s))`, tpl.data)
-    .push(tpl.error('not'));
+  tpl(`if (!${tpl.resolve(schema.not)}(%s)) ${tpl.error('not')}`, tpl.data);
 };

--- a/lib/validators/property.js
+++ b/lib/validators/property.js
@@ -9,11 +9,12 @@ module.exports = function property(schema, tpl) {
         return;
       }
 
-      const propertyExpression = asExpression(properties[key], schema, tpl);
-      if (!propertyExpression) {
+      const condition = asExpression(properties[key], schema, tpl);
+      if (!condition) {
         return;
       }
+      const error = tpl.error(key);
 
-      tpl(`if (${propertyExpression}) ${tpl.error(key)}`, tpl.data, schema[key]);
+      tpl(`if (${condition}) ${error}`, tpl.data, schema[key]);
     });
 };

--- a/lib/validators/required.js
+++ b/lib/validators/required.js
@@ -4,7 +4,9 @@ module.exports = function required(schema, tpl) {
   }
 
   schema.required.forEach((name) => {
-    tpl('if (!%s.hasOwnProperty("%s"))', tpl.data, name)
-      .push(tpl.error('required'));
+    const condition = '!%s.hasOwnProperty("%s")';
+    const error = tpl.error('required', name);
+
+    tpl(`if (${condition}) ${error}`, tpl.data, name);
   });
 };

--- a/lib/validators/type.js
+++ b/lib/validators/type.js
@@ -5,11 +5,8 @@ module.exports = function type(schema, tpl) {
     return;
   }
 
-  if (typeof schema.type === 'string') {
-    tpl(`if (${types[schema.type]})`, tpl.data)
-      .push(tpl.error('type', schema.type));
-  } else if (Array.isArray(schema.type)) {
-    tpl(`if ((${schema.type.map(key => types[key]).join(') && (')}))`, tpl.data)
-      .push(tpl.error('type', schema.type));
-  }
+  const error = tpl.error('type');
+  const condition = `(${[].concat(schema.type).map(key => types[key]).join(') && (')})`;
+
+  tpl(`if (${condition}) ${error}`, tpl.data);
 };


### PR DESCRIPTION
# setErrorHandler(errorHandler: Function)

Specify custom error handler which will be used in generated functions when problem found.
The function should return a string expression, which will be executed when generated validator function is executed. The simpliest use case is the default one @see `template/defaultErrorHandler`
```javascript
 function defaultErrorHandler(errorType) {
   return `return "${errorType}: ${tpl.data}";`;
 }
```
It returns an expression 'return ...', so the output is an error string.

```javascript
djv({ errorHandler: () => 'return { error: true };' }) // => returns an object
djv({
 errorHandler: function customErrorHandler(errorType, property) {
   return `errors.push({
     type: '${type}',
     schema: '${this.schema[this.schema.length - 1]}',
     data: '${this.data[this.data.length - 1]}'
   });
 }
})`;
```
When a custom error handler is used, the template body function adds a `error` variable inside a generated validator, which can be used to put error information. `errorType` is always passed to error handler function. Some validate utilities put extra argument, like f.e. currently processed property value. Inside the handler context is a templater instance, which contains `this.schema`, `this.data` paths arrays to identify validator position.
@see test/index/setErrorHandler for more examples
