### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To instantiate *djv* environment
 ```javascript
 const djv = require('djv');
 const env = djv({
-  version: 'draft-04', // use json-schema draft-06
+  version: 'draft-06', // use json-schema draft-06
   formats: { /*...*/ }, // custom formats @see #addFormat
   errorHandler: () => { /*...*/ }, // custom error handler, @see #setErrorHandler
 });


### PR DESCRIPTION
Looks like `draft-06` was meant instead of` draft-04` in this example (according to comment).