### PR TITLE
Specify files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "description": "dynamic json-schema validator",
   "main": "lib/djv.js",
+  "files": ["lib/djv.js", "djv.js"],
   "scripts": {
     "build": "webpack",
     "changelog": "generate-changelog",


### PR DESCRIPTION
Currently, the files in /lib are picked up which are not transpiled and break on older browsers like IE11. Including "djv.js" in the list of files would help in picking up the correct transpiled file.