### PR TITLE
Fix browser support by adding a browser entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^3.0.0"
   },
   "optionalDependencies": {
-    "@korzio/djv-draft-04": "https://github.com/laurentgoudet/-djv-draft-04.git#bffbd7d"
+    "@korzio/djv-draft-04": "https://github.com/laurentgoudet/-djv-draft-04.git#af4b6a5"
   },
   "spec_dir": "test",
   "spec_files": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^3.0.0"
   },
   "optionalDependencies": {
-    "@korzio/djv-draft-04": "https://github.com/laurentgoudet/-djv-draft-04.git#af4b6a5"
+    "@korzio/djv-draft-04": "https://github.com/laurentgoudet/-djv-draft-04.git#33f5004"
   },
   "spec_dir": "test",
   "spec_files": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^3.0.0"
   },
   "optionalDependencies": {
-    "@korzio/djv-draft-04": "^2.0.0"
+    "@korzio/djv-draft-04": "https://github.com/laurentgoudet/-djv-draft-04.git#bffbd7d"
   },
   "spec_dir": "test",
   "spec_files": [

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.1.0",
   "description": "dynamic json-schema validator",
   "main": "lib/djv.js",
+  "browser": "djv.js",
   "scripts": {
     "build": "webpack",
     "changelog": "generate-changelog",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack": "^3.0.0"
   },
   "optionalDependencies": {
-    "@korzio/djv-draft-04": "https://github.com/laurentgoudet/-djv-draft-04.git#33f5004"
+    "@korzio/djv-draft-04": "^2.0.1"
   },
   "spec_dir": "test",
   "spec_files": [


### PR DESCRIPTION
Currently the library can't easily be used in browser environments as build tools such as webpack would pick the main `lib/djv.js` entry point, which contains ES2015 code. Since a built version is already generated (using `babel-preset-env`), adding a `browser` entry point to `package.json` would fix the issue, allowing webpack (when its `target` is set to `web`) to pick the transpiled one when needed.

`@korzio/djv-draft-04` also needs to be updated as it currently has the same issue.