### PR TITLE
Fix required validator throwing on null values

### DIFF
--- a/lib/validators/required.js
+++ b/lib/validators/required.js
@@ -3,7 +3,7 @@ module.exports = function required(schema, tpl) {
     return;
   }
 
-  tpl(`if (typeof ${tpl.data} === 'object' && !Array.isArray(${tpl.data})) {
+  tpl(`if (${tpl.data} !== null && typeof ${tpl.data} === 'object' && !Array.isArray(${tpl.data})) {
     ${schema.required.map((name) => {
       const condition = `!${tpl.data}.hasOwnProperty("${name}")`;
       const error = tpl.error('required', name);

--- a/test/issues/74.js
+++ b/test/issues/74.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const djv = require('../../');
+
+describe('Issue-74: Required validator throws on null values', () => {
+  const jsonSchema = {
+    def: {
+      type: 'object',
+      properties: {
+        foo: { type: 'string' }
+      },
+      required: ['foo'],
+    },
+  };
+
+  it('should handle nulls without throwing', () => {
+    const env = djv();
+    env.addSchema('issue-74', jsonSchema);
+
+    const obj = null;
+    const errors = env.validate('issue-74#/def', obj);
+    assert.equal(typeof errors, 'object');
+  });
+});


### PR DESCRIPTION
Fixes the `TypeError` by checking explicitly for `null`. The check for `typeof value === 'object'` is not sufficient by itself since:
```js
typeof null // 'object'
```

Closes #74